### PR TITLE
Adjust cert import method to bugfix MethodInvocationException

### DIFF
--- a/Supportscripts/CreateServicePrincipals.psm1
+++ b/Supportscripts/CreateServicePrincipals.psm1
@@ -1,4 +1,4 @@
-﻿function New-M365DSCServicePrincipal
+function New-M365DSCServicePrincipal
 {
     [CmdletBinding()]
     param
@@ -75,8 +75,7 @@
 
         try
         {
-            $certObj = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-            $certObj.Import($CertificatePath)
+            $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2($CertificatePath)
         }
         catch
         {
@@ -252,8 +251,7 @@
 
         $applicationId = $app.AppId
 
-        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-        $cert.Import($CertificatePath)
+        $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2($CertificatePath)
 
         $certThumbprint = $cert.Thumbprint
 

--- a/Tests/QA/QualityAssurance.Tests.ps1
+++ b/Tests/QA/QualityAssurance.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeDiscovery {
+BeforeDiscovery {
     $workingDirectoryCICD = $PSScriptRoot
     $rootDirectoryCICD = Split-Path -Path (Split-Path -Path $workingDirectoryCICD -Parent) -Parent
     $rootDirectoryData = Join-Path -Path (Split-Path -Path $rootDirectoryCICD -Parent) -ChildPath 'Data'
@@ -28,7 +28,7 @@
     $allEnvFileName = $envFiles | ForEach-Object { @{ BaseName = $_.BaseName; FolderName = $_.Directory.Name } }
 
     $filesInDataRepo = @()
-    $items = Get-ChildItem -Path $rootDirectoryData -Exclude ".git*","Supportscripts",".vscode*" | Get-ChildItem -Recurse -File
+    $items = Get-ChildItem -Path $rootDirectoryData -Exclude ".git*","Supportscripts",".vscode*","LICENSE" | Get-ChildItem -Recurse -File
     foreach ($item in $items)
     {
         $filesInDataRepo += @{
@@ -38,7 +38,7 @@
     }
 
     $filesInCICDRepo = @()
-    $items = Get-ChildItem -Path $rootDirectoryCICD -Exclude ".git*","Supportscripts",".vscode*" | Foreach-Object { Get-ChildItem -Path $_.FullName -Recurse -File -Exclude "*.dll*" }
+    $items = Get-ChildItem -Path $rootDirectoryCICD -Exclude ".git*","Supportscripts",".vscode*","LICENSE" | Foreach-Object { Get-ChildItem -Path $_.FullName -Recurse -File -Exclude "*.dll*" }
     foreach ($item in $items)
     {
         $filesInCICDRepo += @{


### PR DESCRIPTION
Couple of minor bugfixes I ran into while setting this up for the first time in a test environment.

Adjust cert import method to bugfix MethodInvocationException: Exception calling "Import" with "1" argument(s): "X509Certificate is immutable on this platform. Use the equivalent constructor instead."

Unsure of exactly what causes this issue, PowerShell 5 vs 7/Core didn't seem to matter but this did fix it while I was setting things up.

Also excluded the license files from the tests since the pipeline would fail otherwise.